### PR TITLE
Fix parsing of inputted hex colors

### DIFF
--- a/website/picker.js
+++ b/website/picker.js
@@ -13,8 +13,14 @@ const height = size;
 const width = size;
 
 
-function stringIsValidHex(string) {
-    return string.match(/#?[0-9a-f]{6}/i);
+function tryParseStringAsHex(string) {
+    const match = string.match(/^\s*#?([0-9a-f]{6})\s*$/i);
+    if (match) {
+        const matchedHexDigits = match[1];
+        return '#' + matchedHexDigits;
+    } else {
+        return null;
+    }
 }
 
 function stringIsNumberWithinRange(string, min, max) {
@@ -377,8 +383,9 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     elInputHex.addEventListener('input', function () {
-        if (stringIsValidHex(elInputHex.value)) {
-            let hsl = hsluv.Hsluv.hexToHsluv(elInputHex.value);
+        const valueAsHex = tryParseStringAsHex(elInputHex.value);
+        if (valueAsHex !== null) {
+            const hsl = hsluv.Hsluv.hexToHsluv(valueAsHex);
             H = hsl[0];
             S = hsl[1];
             L = hsl[2];


### PR DESCRIPTION
Before this fix, if you pasted a color “aa22cc” with no leading “#”, the picker accepted the color as correct but skipped its first character, interpreting the color as #a22cc0. Now it will accept the color as correct and interpret it as #aa22cc.

It’s not important, but I will mention that the picker will do nothing if there is extraneous text around the inputted hex code, e.g. if the input is “I can’t decide between 000000 and fe57a1”. I could have instead made it search for the first hex-code-like string within the input. I don’t have strong feelings on which behavior is better, so I implemented the first one.

---

I was unable to test my fix by building the website and serving it locally. But I did manually test the function `tryParseStringAsHex` against a lot of inputs in a `node` REPL, so it will probably work.

Here are the errors I ran into when trying to build the website to test it, with Nix 2.3.3 on macOS 10.14.6:

~~~
$ nix-build -A website
these derivations will be built:
  /nix/store/jdf8dv5msihzphfp06knw55fprdmyzd1-hsluv-js-compile.drv
  /nix/store/9dkpm4bwr7sa84fkyq5lv045244qh33a-js-node-package.drv
  /nix/store/aaa1rxmxwccky66wz91kw9i0cslgq118-source.drv
  /nix/store/spanrrkrmw9n2dqjacpx611f8gwp4jxm-source.drv
  /nix/store/v8k8747jl7c5231dlmf2w31jggci6g3h-node-modules.drv
  /nix/store/dg14vdqf3a7w8841a404nqhq0dpj5ml5-hsluv-website-demo-images.drv
  /nix/store/l1vzwmvp46vz1wqcgcb8vad7iqp0gl8v-hsluv-js-compile.drv
  /nix/store/9r12iaz21jqr7lmhnyllkhk7wi3kdidj-picker-js.drv
  /nix/store/npf5c60drid9zv824yssailzzlgxdrcz-hsluv-js.drv
  /nix/store/8xxn6akhmcfa0cj0dmdf3qlrw556ig2b-hsluv-website.drv
building '/nix/store/aaa1rxmxwccky66wz91kw9i0cslgq118-source.drv'...
dyld: Library not loaded: /usr/lib/system/libsystem_network.dylib
  Referenced from: /nix/store/i1ds9mm865idswzf9a5cpafb1wgvzqih-Libsystem-osx-10.11.6/lib/libSystem.B.dylib
  Reason: image not found
builder for '/nix/store/aaa1rxmxwccky66wz91kw9i0cslgq118-source.drv' failed due to signal 6 (Abort trap: 6)
building '/nix/store/l1vzwmvp46vz1wqcgcb8vad7iqp0gl8v-hsluv-js-compile.drv'...
cannot build derivation '/nix/store/v8k8747jl7c5231dlmf2w31jggci6g3h-node-modules.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/8xxn6akhmcfa0cj0dmdf3qlrw556ig2b-hsluv-website.drv': 1 dependencies couldn't be built
error: build of '/nix/store/8xxn6akhmcfa0cj0dmdf3qlrw556ig2b-hsluv-website.drv' failed
~~~

~~~
$ ./run.sh server
these derivations will be built:
  /nix/store/76mz25gpnimvd681v6x0560ylsbklfab-python3-3.6.4-env.drv
  /nix/store/jdf8dv5msihzphfp06knw55fprdmyzd1-hsluv-js-compile.drv
  /nix/store/9dkpm4bwr7sa84fkyq5lv045244qh33a-js-node-package.drv
  /nix/store/aaa1rxmxwccky66wz91kw9i0cslgq118-source.drv
  /nix/store/spanrrkrmw9n2dqjacpx611f8gwp4jxm-source.drv
  /nix/store/v8k8747jl7c5231dlmf2w31jggci6g3h-node-modules.drv
  /nix/store/dg14vdqf3a7w8841a404nqhq0dpj5ml5-hsluv-website-demo-images.drv
  /nix/store/l1vzwmvp46vz1wqcgcb8vad7iqp0gl8v-hsluv-js-compile.drv
  /nix/store/9r12iaz21jqr7lmhnyllkhk7wi3kdidj-picker-js.drv
  /nix/store/npf5c60drid9zv824yssailzzlgxdrcz-hsluv-js.drv
  /nix/store/8xxn6akhmcfa0cj0dmdf3qlrw556ig2b-hsluv-website.drv
  /nix/store/icjb9hl9rn0j5vm45nz987jzh4wlhjnb-script.sh.drv
building '/nix/store/76mz25gpnimvd681v6x0560ylsbklfab-python3-3.6.4-env.drv'...
dyld: Library not loaded: /usr/lib/system/libsystem_network.dylib
  Referenced from: /nix/store/i1ds9mm865idswzf9a5cpafb1wgvzqih-Libsystem-osx-10.11.6/lib/libSystem.B.dylib
  Reason: image not found
builder for '/nix/store/76mz25gpnimvd681v6x0560ylsbklfab-python3-3.6.4-env.drv' failed due to signal 6 (Abort trap: 6)
cannot build derivation '/nix/store/icjb9hl9rn0j5vm45nz987jzh4wlhjnb-script.sh.drv': 1 dependencies couldn't be built
error: build of '/nix/store/icjb9hl9rn0j5vm45nz987jzh4wlhjnb-script.sh.drv' failed
./run.sh: line 5: ./secrets.txt: No such file or directory
./run.sh: line 6: /bin/script.sh: No such file or directory
~~~

I have never used Nix for anything else, so I can’t tell whether this is a problem with hsluv’s usage of Nix or a problem with my whole Nix installation.