### PR TITLE
Allow a build with only Docker around (fixes #63)

### DIFF
--- a/.github/workflows/build_and_test_using_docker.yml
+++ b/.github/workflows/build_and_test_using_docker.yml
@@ -1,0 +1,19 @@
+# Copyright (C) 2020 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the MIT license
+
+name: Build and test using Docker
+
+on:
+- pull_request
+- push
+
+jobs:
+  build_and_test:
+    name: Build and test using Docker
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Docker image
+        run: |-
+          docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Copyright (C) 2020 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the MIT license
+
+FROM ubuntu:18.04
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+        && \
+    apt-get update \
+        && \
+    apt-get dist-upgrade --yes --no-install-recommends \
+        && \
+    apt-get install --yes --no-install-recommends \
+            bzip2 \
+            ca-certificates \
+            curl \
+            sudo \
+            xz-utils
+
+RUN useradd --create-home --non-unique --uid 1000 nix \
+        && \
+    echo 'nix ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
+USER nix
+ENV USER=nix NIX_CURL_FLAGS='--retry-connrefused --silent --show-error'
+RUN mkdir /home/nix/hsluv
+
+RUN curl ${NIX_CURL_FLAGS} -L https://nixos.org/nix/install | sh
+
+# Make sure that all future RUN commands have nix.sh sourced, first.
+# NOTE: nix.sh needs ${HOME} and ${USER} set
+ENV BASH_ENV=/home/nix/.nix-profile/etc/profile.d/nix.sh
+SHELL ["bash", "-c"]
+
+RUN nix-env --version
+
+RUN nix-instantiate --eval -E 'with import <nixpkgs> {}; lib.version or lib.nixpkgsVersion'
+
+COPY --chown=nix:nix default.nix  /home/nix/hsluv/
+COPY --chown=nix:nix javascript/  /home/nix/hsluv/javascript/
+COPY --chown=nix:nix haxe/        /home/nix/hsluv/haxe/
+COPY --chown=nix:nix snapshots/   /home/nix/hsluv/snapshots/
+COPY --chown=nix:nix website/     /home/nix/hsluv/website/
+
+WORKDIR /home/nix/hsluv/
+
+RUN nix-build -A test
+RUN nix-build -A website

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@ rec {
   # Known issue on MacOS https://github.com/HaxeFoundation/haxe/issues/6866
   # Because Nix is broken on Catalina we are giving up on MacOS for the time being and waiting for official support
   pkgsSrc = pkgsOriginal.fetchzip {
-    url = "https://github.com/NixOS/nixpkgs/archive/c7363c2b97e0e4eb127e6a32b3207cc00eac3409.zip";
-    sha256 = "1cn175ghzg5nzchxzcmdbwj6143q0q7am1gqdpypjdbcdkpghrqp";
+    url = "https://github.com/NixOS/nixpkgs/archive/3ab38ef086947822fbe2cffea071e1c508811990.zip";
+    sha256 = "004x04v07xdp444ilb4sjxprnsjy4g2ji7fq8sydjyf9gvn6b85f";
   };
 
   jre = pkgs.jre;


### PR DESCRIPTION
Fixes #63

Hi!

This pull request adds two things:
- A `Dockerfile` based on Ubuntu mimicking [the steps taken](https://travis-ci.org/github/hsluv/hsluv/builds/667517112) by the existing Travis CI.
- Simple integration for GitHub Actions that builds the Docker image.

Say about Ubuntu what you like, but I consider having Ubuntu for a base a feature with regard to allowing more contribution. Still, if you are sure you want a Nix image as the base image I won't stand in the way. This new CI *can* replace Travis CI later but it doesn't have to.

Please let me know what you think.

PS: This thing sits on top of #70 because the CI has little chance to pass without it. Happy to rebase off it once that #70 is merged.

PPS: Readme integration is not done yet. I welcome input on how to best do that.